### PR TITLE
DX-257 - Externalize static assets config

### DIFF
--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -87,20 +87,10 @@ export default defineConfigWithTheme<ThemeConfig>({
     // https://github.com/vitejs/vite/issues/7854
     reactivityTransform: resolve(__dirname, 'src'), // true
   },
-  async buildEnd(){
-
-    copyAdditionalAssets([
-      // added to meteor-icon-kit/.github/scripts/docs.yml
-      'resources/meteor-icon-kit/public/icons/regular',
-      'resources/meteor-icon-kit/public/icons/solid',
-      // added to admin-extension-sdk/.github/scripts/docs.yml
-      'resources/admin-extension-sdk/api-reference/assets',
-      'resources/admin-extension-sdk/api-reference/ui/assets',
-      'resources/admin-extension-sdk/concepts/assets',
-      'resources/admin-extension-sdk/getting-started/assets',
-      'resources/admin-extension-sdk/internals/assets',
-      'resources/admin-extension-sdk/tooling/assets',
-    ]);
-
+  async buildEnd() {
+    /**
+     * Copy additional assets not present in the assets or public dir.
+     */
+    await copyAdditionalAssets();
   }
 });

--- a/cli/src/commands/link.ts
+++ b/cli/src/commands/link.ts
@@ -3,6 +3,7 @@ import {optionDst, optionSrc} from "../options";
 import {output} from "../output";
 import fs from "fs";
 import {execSync} from "child_process";
+import {copyConfig} from "../procedure/copyConfig";
 
 export default {
     name: 'link',
@@ -122,6 +123,9 @@ export default {
 
         // rsync into destination
         await strategy({src, dst});
+
+        // copy additional config
+        await copyConfig(src, dst);
 
         output.success('Docs directory linked');
     }

--- a/cli/src/procedure/clone.ts
+++ b/cli/src/procedure/clone.ts
@@ -3,9 +3,9 @@ import fs from "fs";
 import {getDeveloperPortalPath, run} from "../helpers";
 import {execSync} from 'child_process';
 import {v4 as uuid} from 'uuid';
-import confirm from "@inquirer/confirm";
 import inquirer from "inquirer";
 import cloneCommand from "../commands/clone";
+import {copyConfig} from "./copyConfig";
 
 export const clone = async ({
                                 repository, // 1
@@ -76,6 +76,9 @@ export const clone = async ({
         // create a new symlink
         output.notice(`Copying ${src} to ${dst}`);
         await run('cp', ['-ra', `${src}/.`, `${dst}/`], {dir: tmpDir});
+
+        // copy additional config
+        await copyConfig(tmpDir, dst);
     } catch (e) {
         caughtException = e;
     }

--- a/cli/src/procedure/copyConfig.ts
+++ b/cli/src/procedure/copyConfig.ts
@@ -4,7 +4,7 @@ import {run} from "../helpers";
 
 export const copyConfig = async (src: string, dst: string) => {
     const docsConfig = '.github/scripts/docs.yml';
-    if (!fs.existsSync(`${src}/${docsConfig}`) || !fs.lstatSync(`${dst}/${docsConfig}`).isFile()) {
+    if (!fs.existsSync(`${src}/${docsConfig}`) || !fs.lstatSync(`${src}/${docsConfig}`).isFile()) {
         return;
     }
     

--- a/cli/src/procedure/copyConfig.ts
+++ b/cli/src/procedure/copyConfig.ts
@@ -1,0 +1,13 @@
+import fs from "fs";
+import {output} from "../output";
+import {run} from "../helpers";
+
+export const copyConfig = async (src: string, dst: string) => {
+    const docsConfig = '.github/scripts/docs.yml';
+    if (!fs.existsSync(`${src}/${docsConfig}`) || !fs.lstatSync(`${dst}/${docsConfig}`).isFile()) {
+        return;
+    }
+    
+    output.notice('Copying external config');
+    await run('cp', [`${src}/${docsConfig}`, `${dst}/docs.yml`]);
+}

--- a/cli/src/procedure/copyConfig.ts
+++ b/cli/src/procedure/copyConfig.ts
@@ -9,5 +9,5 @@ export const copyConfig = async (src: string, dst: string) => {
     }
     
     output.notice('Copying external config');
-    await run('cp', [`${src}/${docsConfig}`, `${dst}/docs.yml`]);
+    await run('cp', [`${src}/${docsConfig}`, `${dst}/docs.yml`], {dir: src});
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "esModuleInterop": true,
     "types": [
       "jest",
       "@playwright/test"


### PR DESCRIPTION
This PR:
 - [X] removes hardcoded static assets path from the `developer-portal`
 - [X] replaces it with in-repository `docs.yml`, keeping the control in the external repository for simpler management