### PR TITLE
DX-272 - Move MarkdownTransform from frontends

### DIFF
--- a/.github/workflows/checkout-test-build-deploy.yml
+++ b/.github/workflows/checkout-test-build-deploy.yml
@@ -94,7 +94,7 @@ jobs:
 
       - name: Test
         run: |
-          export NODE_OPTIONS="--max-old-space-size=3072"
+          export NODE_OPTIONS="--max-old-space-size=4096"
           pnpm run test
 
   test-build:
@@ -119,12 +119,12 @@ jobs:
 
       - name: Build project
         run: |
-          export NODE_OPTIONS="--max-old-space-size=3072"
+          export NODE_OPTIONS="--max-old-space-size=4096"
           pnpm run build
 
       - name: Test
         run: |
-          export NODE_OPTIONS="--max-old-space-size=3072"
+          export NODE_OPTIONS="--max-old-space-size=4096"
           pnpm run test:build
 
       - name: Zip folder

--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -3,6 +3,7 @@ import type { Config as ThemeConfig } from "vitepress-shopware-docs";
 import baseConfig from "vitepress-shopware-docs/config";
 import ViteRequireContext from '@originjs/vite-plugin-require-context'
 const {resolve} = require('path');
+import { MarkdownTransform } from "./plugins/markdownTransform";
 
 import {copyAdditionalAssets} from "./helpers";
 import navigation from "./navigation";
@@ -11,8 +12,8 @@ export default defineConfigWithTheme<ThemeConfig>({
   extends: baseConfig,
 
   lang: "en-US",
-  title: "Shopware",
-  description: "Name of the documentation",
+  title: "Shopware Documentation",
+  description: "Documentation for Shopware developers",
   srcDir: "src",
   srcExclude: [],
   scrollOffset: "header",
@@ -78,6 +79,7 @@ export default defineConfigWithTheme<ThemeConfig>({
       ViteRequireContext({
         projectBasePath: `${process.cwd()}/src`
       }),
+      MarkdownTransform(),
     ],
   },
 

--- a/.vitepress/plugins/markdownTransform.ts
+++ b/.vitepress/plugins/markdownTransform.ts
@@ -1,0 +1,73 @@
+import { join, resolve } from "path";
+import type { Plugin } from "vite";
+import fs from "fs-extra";
+import {
+  getTypeDefinition,
+  isTypeDefinitionExists,
+  replacer,
+} from "../utils";
+
+export function MarkdownTransform(): Plugin {
+  return {
+    name: "vueuse-md-transform",
+    enforce: "pre",
+    async transform(code, id) {
+      if (!id.match(/\.md\b/)) return null;
+
+      const [pkg, fileName] = id.split("/").slice(-2);
+      const composableName = fileName.replace(/\.md$/, "");
+
+      // If we don't have a type definition, skip
+      if (!isTypeDefinitionExists(pkg, composableName)) return null;
+
+      const frontmatterEnds = code.indexOf("---\n\n") + 4;
+      const firstSubheader = code.search(/\n## \w/);
+      const sliceIndex = firstSubheader < 0 ? frontmatterEnds : firstSubheader;
+
+      const { footer } = await getFunctionMarkdown(pkg, composableName);
+
+      code = replacer(code, footer, "FOOTER", "tail");
+
+      return code;
+    },
+  };
+}
+
+const DIR_SRC = resolve(__dirname, "../..");
+
+export async function getFunctionMarkdown(pkg: string, name: string) {
+  const hasDemo = fs.existsSync(join(DIR_SRC, pkg, name, "demo.vue"));
+  const types = await getTypeDefinition(pkg, name);
+
+  let typingSection = "";
+
+  if (types) {
+    const code = `\`\`\`typescript\n${types.trim()}\n\`\`\``;
+    typingSection = `
+\n
+## Type Declarations
+
+:::warning
+Composable types are in an early stage, public API may change in the future. Please check here regularly for updates.
+:::
+\n
+    `;
+    typingSection +=
+      types.length > 1000
+        ? `
+<details>
+<summary op50 italic>Show Type Declarations</summary>
+
+${code}
+
+</details>
+`
+        : `\n\n${code}`;
+  }
+
+  const footer = `${typingSection}\n\n`;
+
+  return {
+    footer,
+  };
+}

--- a/.vitepress/utils.ts
+++ b/.vitepress/utils.ts
@@ -1,0 +1,63 @@
+import { join } from "path";
+import fs from "fs-extra";
+import parser from "prettier/parser-typescript";
+import prettier from "prettier";
+
+export function isTypeDefinitionExists(pkg: string, name: string) {
+    const typingFilepath = join(
+        __dirname,
+        `../packages/${pkg}/temp/${name}.d.ts`
+    );
+    return fs.existsSync(typingFilepath);
+}
+
+export async function getTypeDefinition(
+    pkg: string,
+    name: string
+): Promise<string | undefined> {
+    const typingFilepath = join(
+        __dirname,
+        `../packages/${pkg}/temp/${name}.d.ts`
+    );
+
+    if (!fs.existsSync(typingFilepath)) return;
+
+    let types = await fs.readFile(typingFilepath, "utf-8");
+
+    if (!types) return;
+
+    // clean up types
+    types = types
+        .replace(/import\(.*?\)\./g, "")
+        .replace(/import[\s\S]+?from ?["'][\s\S]+?["']/g, "")
+        .replace(/export {}/g, "");
+
+    return prettier
+        .format(types, {
+            semi: false,
+            parser: "typescript",
+            plugins: [parser],
+        })
+        .trim();
+}
+
+export function replacer(
+    code: string,
+    value: string,
+    key: string,
+    insert: "head" | "tail" | "none" = "none"
+) {
+    const START = `<!--${key}_STARTS-->`;
+    const END = `<!--${key}_ENDS-->`;
+    const regex = new RegExp(`${START}[\\s\\S]*?${END}`, "im");
+
+    const target = value ? `${START}\n${value}\n${END}` : `${START}${END}`;
+
+    if (!code.match(regex)) {
+        if (insert === "none") return code;
+        else if (insert === "head") return `${target}\n\n${code}`;
+        else return `${code}\n\n${target}`;
+    }
+
+    return code.replace(regex, target);
+}

--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
     "execa": "^6.1.0",
     "shell-escape": "^0.2.0",
     "jest-image-snapshot": "^6.1.0",
-    "slugify": "^1.6.5"
+    "slugify": "^1.6.5",
+    "prettier": "^2.8.3"
   },
   "pnpm": {
     "peerDependencyRules": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,6 +21,7 @@ importers:
       jest-expect-message: ^1.1.3
       jest-image-snapshot: ^6.1.0
       playwright-chromium: ^1.30.0
+      prettier: ^2.8.3
       sass: ^1.57.1
       shell-escape: ^0.2.0
       slugify: ^1.6.5
@@ -55,6 +56,7 @@ importers:
       jest-expect-message: 1.1.3
       jest-image-snapshot: 6.1.0
       playwright-chromium: 1.30.0
+      prettier: 2.8.3
       sass: 1.57.1
       shell-escape: 0.2.0
       slugify: 1.6.5
@@ -5847,6 +5849,12 @@ packages:
       simple-get: 3.1.1
       tar-fs: 2.1.1
       tunnel-agent: 0.6.0
+    dev: true
+
+  /prettier/2.8.3:
+    resolution: {integrity: sha512-tJ/oJ4amDihPoufT5sM0Z1SKEuKay8LfVAMlbbhnnkvt6BUserZylqo2PN+p9KeljLr0OHa2rXHU1T8reeoTrw==}
+    engines: {node: '>=10.13.0'}
+    hasBin: true
     dev: true
 
   /pretty-format/26.6.2:


### PR DESCRIPTION
This PR moves `MarkdownTransform` vitepress plugin and its utils from `shopware/frontends`.