### PR TITLE
DX-278 - Force redirect to .html

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -17,5 +17,12 @@
         }
       ]
     }
+  ],
+  "redirects": [
+    {
+      "source": ":url(^(?!.*\\.).*[^/]$)",
+      "destination": ":url.html",
+      "statusCode": 301
+    }
   ]
 }


### PR DESCRIPTION
This PR adds Vercel redirect for handling non-html links and force-redirect them with .html extension.

As a consequence, this also fixes 404 status code and 404 page displayed on successful redirect.