### PR TITLE
Update playwright & chromium

### DIFF
--- a/.github/actions/checkout-install/action.yml
+++ b/.github/actions/checkout-install/action.yml
@@ -19,7 +19,7 @@ runs:
       with:
         version: 7
 
-    - name: Install system
+    - name: Install system (Playwright requirements)
       shell: bash
       if: ${{ inputs.apt }}
       run: |

--- a/.github/actions/checkout-install/action.yml
+++ b/.github/actions/checkout-install/action.yml
@@ -19,6 +19,11 @@ runs:
       with:
         version: 7
 
+    - name: Add backports
+      run: |
+        sudo add-apt-repository -y "deb http://archive.ubuntu.com/ubuntu $(lsb_release -cs)-backports main restricted universe multiverse "
+        sudo add-apt-repository -y "deb http://archive.ubuntu.com/ubuntu $(lsb_release -cs)-security main restricted universe multiverse "
+
     - name: Install system (Playwright requirements)
       shell: bash
       if: ${{ inputs.apt }}

--- a/.github/actions/checkout-install/action.yml
+++ b/.github/actions/checkout-install/action.yml
@@ -20,6 +20,7 @@ runs:
         version: 7
 
     - name: Add backports
+      shell: bash
       run: |
         sudo add-apt-repository -y "deb http://archive.ubuntu.com/ubuntu $(lsb_release -cs)-backports main restricted universe multiverse "
         sudo add-apt-repository -y "deb http://archive.ubuntu.com/ubuntu $(lsb_release -cs)-security main restricted universe multiverse "

--- a/FAQ.md
+++ b/FAQ.md
@@ -28,6 +28,38 @@ more info.
 Give it another try. Sometimes the process takes too long and reaches the timeout setting. You can also try running the
 pipeline locally using the [./.github/scripts/act.sh](./.github/scripts/act.sh).
 
+## Can I run the whole workflow locally?
+
+Yes, you can use [`nektos/act`](https://github.com/nektos/act) for that purpose. First, follow the install instructions
+for your OS.
+
+Then copy `./.act.env.sample` to `./.act.env` and edit env vars for Figma and GitHub.
+
+```bash
+$ cp ./.act.env.sample ./.act.env
+$ nano ./.act.env
+```
+
+To list all available jobs run the following command.
+
+```bash
+$ ./bin/act -l
+```
+
+For running a selected job run the command below and pass the `--secret-file` option.
+
+```bash
+# run embed-docs and test-cli steps
+$ ./bin/act -j embed-docs --secret-file ./.act.env
+$ ./bin/act -j test-cli --secret-file ./.act.env
+```
+
+To draw a workflow graph:
+
+```bash
+$ ./bin/act -g
+```
+
 ## What is the difference between the library and project?
 
 Library (`developer-documentation-vitepress`) holds Shopware-flavoured Vitepress theme that can be reused by different

--- a/__tests__/e2e/index.test.ts
+++ b/__tests__/e2e/index.test.ts
@@ -6,7 +6,7 @@ describe('render correct content', async () => {
     test('navigation', async() => {
         const navBarLocator = page.locator('.VPNavBarMenu > .VPNavBarMenuLink');
         const links = await navBarLocator.allTextContents()
-        expect(links).toEqual(['Apps', 'Themes', 'Frontends', 'Integrations'])
+        expect(links).toEqual(['Docs', 'Apps', 'Themes', 'Plugins', 'Frontends', 'Integrations'])
 
         const subNavBarLocator = page.locator('.VPNavBarMenu > .VPNavBarMenuGroup .vt-flyout-button-text');
         const groupLinks = await subNavBarLocator.allTextContents()

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "devDependencies": {
     "@originjs/vite-plugin-require-context": "^1.0.9",
-    "@playwright/test": "^1.31.2",
+    "@playwright/test": "^1.32.1",
     "@storybook/addon-essentials": "^7.0.0-rc.6",
     "@storybook/addon-interactions": "^7.0.0-rc.6",
     "@storybook/addon-links": "^7.0.0-rc.6",
@@ -57,7 +57,7 @@
     "jest-expect-message": "^1.1.3",
     "jest-image-snapshot": "^6.1.0",
     "mermaid": "9.1.7",
-    "playwright-chromium": "^1.31.2",
+    "playwright-chromium": "^1.32.1",
     "prettier": "^2.8.4",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "jest-expect-message": "^1.1.3",
     "jest-image-snapshot": "^6.1.0",
     "mermaid": "9.1.7",
-    "playwright-chromium": "1.30.0",
+    "playwright-chromium": "^1.32.1",
     "prettier": "^2.8.4",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "devDependencies": {
     "@originjs/vite-plugin-require-context": "^1.0.9",
-    "@playwright/test": "^1.32.1",
+    "@playwright/test": "^1.30.0",
     "@storybook/addon-essentials": "^7.0.0-rc.6",
     "@storybook/addon-interactions": "^7.0.0-rc.6",
     "@storybook/addon-links": "^7.0.0-rc.6",
@@ -57,7 +57,7 @@
     "jest-expect-message": "^1.1.3",
     "jest-image-snapshot": "^6.1.0",
     "mermaid": "9.1.7",
-    "playwright-chromium": "^1.32.1",
+    "playwright-chromium": "1.30.0",
     "prettier": "^2.8.4",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ importers:
   .:
     specifiers:
       '@originjs/vite-plugin-require-context': ^1.0.9
-      '@playwright/test': ^1.32.1
+      '@playwright/test': ^1.30.0
       '@storybook/addon-essentials': ^7.0.0-rc.6
       '@storybook/addon-interactions': ^7.0.0-rc.6
       '@storybook/addon-links': ^7.0.0-rc.6
@@ -30,7 +30,7 @@ importers:
       jest-expect-message: ^1.1.3
       jest-image-snapshot: ^6.1.0
       mermaid: 9.1.7
-      playwright-chromium: ^1.32.1
+      playwright-chromium: 1.30.0
       prettier: ^2.8.4
       react: ^18.2.0
       react-dom: ^18.2.0
@@ -81,7 +81,7 @@ importers:
       jest-expect-message: 1.1.3
       jest-image-snapshot: 6.1.0
       mermaid: 9.1.7
-      playwright-chromium: 1.32.1
+      playwright-chromium: 1.30.0
       prettier: 2.8.4
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
@@ -608,7 +608,6 @@ packages:
     hasBin: true
     dependencies:
       '@babel/types': 7.21.3
-    dev: true
 
   /@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/7.18.6_@babel+core@7.21.3:
     resolution: {integrity: sha512-Dgxsyg54Fx1d4Nge8UnvTrED63vrwOdPmyvPzlNN/boaliRP54pm3pGzZD1SJUwrBA+Cs/xdG8kXX6Mn/RfISQ==}
@@ -1585,7 +1584,6 @@ packages:
       '@babel/helper-string-parser': 7.19.4
       '@babel/helper-validator-identifier': 7.19.1
       to-fast-properties: 2.0.0
-    dev: true
 
   /@bcoe/v8-coverage/0.2.3:
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
@@ -4085,8 +4083,8 @@ packages:
   /@types/babel__core/7.20.0:
     resolution: {integrity: sha512-+n8dL/9GWblDO0iU6eZAwEIJVr5DWigtle+Q6HLOrh/pdbXOhOtqzq8VPPE2zvNJzSKY4vH/z3iT3tn0A3ypiQ==}
     dependencies:
-      '@babel/parser': 7.21.2
-      '@babel/types': 7.21.2
+      '@babel/parser': 7.21.3
+      '@babel/types': 7.21.3
       '@types/babel__generator': 7.6.4
       '@types/babel__template': 7.4.1
       '@types/babel__traverse': 7.18.3
@@ -4439,7 +4437,7 @@ packages:
   /@types/through/0.0.30:
     resolution: {integrity: sha512-FvnCJljyxhPM3gkRgWmxmDZyAQSiBQQWLI0A0VFL0K7W1oRUrPJSqNO0NvTnLkBcotdlp3lKvaT0JrnyRDkzOg==}
     dependencies:
-      '@types/node': 18.14.2
+      '@types/node': 18.15.1
     dev: true
 
   /@types/treeify/1.0.0:
@@ -4773,7 +4771,7 @@ packages:
   /@vue/reactivity-transform/3.2.47:
     resolution: {integrity: sha512-m8lGXw8rdnPVVIdIFhf0LeQ/ixyHkH5plYuS83yop5n7ggVJU+z5v0zecwEnX7fa7HNLBhh2qngJJkxpwEEmYA==}
     dependencies:
-      '@babel/parser': 7.21.2
+      '@babel/parser': 7.21.3
       '@vue/compiler-core': 3.2.47
       '@vue/shared': 3.2.47
       estree-walker: 2.0.2
@@ -10176,13 +10174,19 @@ packages:
       - supports-color
     dev: true
 
-  /playwright-chromium/1.32.1:
-    resolution: {integrity: sha512-TADlQ5xJ4iHIHLKQw361PrleUMHJIRlrw+yDadd3IWS0TCHL+CpMjGhSV9OZbKdsi0oZxjDudwd8B2d6lzjfmw==}
+  /playwright-chromium/1.30.0:
+    resolution: {integrity: sha512-ZfqjYdFuxnZxK02mDZtHFK/Mi0+cjCVn51RmwLwLLHA8PkCExk0odmZH2REx+LjqX8tDLGnmf6vDnPAirdSY0g==}
     engines: {node: '>=14'}
     hasBin: true
     requiresBuild: true
     dependencies:
-      playwright-core: 1.32.1
+      playwright-core: 1.30.0
+    dev: true
+
+  /playwright-core/1.30.0:
+    resolution: {integrity: sha512-7AnRmTCf+GVYhHbLJsGUtskWTE33SwMZkybJ0v6rqR1boxq2x36U7p1vDRV7HO2IwTZgmycracLxPEJI49wu4g==}
+    engines: {node: '>=14'}
+    hasBin: true
     dev: true
 
   /playwright-core/1.32.1:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,7 +30,7 @@ importers:
       jest-expect-message: ^1.1.3
       jest-image-snapshot: ^6.1.0
       mermaid: 9.1.7
-      playwright-chromium: 1.30.0
+      playwright-chromium: ^1.32.1
       prettier: ^2.8.4
       react: ^18.2.0
       react-dom: ^18.2.0
@@ -81,7 +81,7 @@ importers:
       jest-expect-message: 1.1.3
       jest-image-snapshot: 6.1.0
       mermaid: 9.1.7
-      playwright-chromium: 1.30.0
+      playwright-chromium: 1.32.1
       prettier: 2.8.4
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
@@ -10174,19 +10174,13 @@ packages:
       - supports-color
     dev: true
 
-  /playwright-chromium/1.30.0:
-    resolution: {integrity: sha512-ZfqjYdFuxnZxK02mDZtHFK/Mi0+cjCVn51RmwLwLLHA8PkCExk0odmZH2REx+LjqX8tDLGnmf6vDnPAirdSY0g==}
+  /playwright-chromium/1.32.1:
+    resolution: {integrity: sha512-TADlQ5xJ4iHIHLKQw361PrleUMHJIRlrw+yDadd3IWS0TCHL+CpMjGhSV9OZbKdsi0oZxjDudwd8B2d6lzjfmw==}
     engines: {node: '>=14'}
     hasBin: true
     requiresBuild: true
     dependencies:
-      playwright-core: 1.30.0
-    dev: true
-
-  /playwright-core/1.30.0:
-    resolution: {integrity: sha512-7AnRmTCf+GVYhHbLJsGUtskWTE33SwMZkybJ0v6rqR1boxq2x36U7p1vDRV7HO2IwTZgmycracLxPEJI49wu4g==}
-    engines: {node: '>=14'}
-    hasBin: true
+      playwright-core: 1.32.1
     dev: true
 
   /playwright-core/1.32.1:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ importers:
   .:
     specifiers:
       '@originjs/vite-plugin-require-context': ^1.0.9
-      '@playwright/test': ^1.31.2
+      '@playwright/test': ^1.32.1
       '@storybook/addon-essentials': ^7.0.0-rc.6
       '@storybook/addon-interactions': ^7.0.0-rc.6
       '@storybook/addon-links': ^7.0.0-rc.6
@@ -30,7 +30,7 @@ importers:
       jest-expect-message: ^1.1.3
       jest-image-snapshot: ^6.1.0
       mermaid: 9.1.7
-      playwright-chromium: ^1.31.2
+      playwright-chromium: ^1.32.1
       prettier: ^2.8.4
       react: ^18.2.0
       react-dom: ^18.2.0
@@ -56,7 +56,7 @@ importers:
       vue: 3.2.47
     devDependencies:
       '@originjs/vite-plugin-require-context': 1.0.9
-      '@playwright/test': 1.31.2
+      '@playwright/test': 1.32.1
       '@storybook/addon-essentials': 7.0.0-rc.7_biqbaboplfbrettd7655fr4n2y
       '@storybook/addon-interactions': 7.0.0-rc.7_biqbaboplfbrettd7655fr4n2y
       '@storybook/addon-links': 7.0.0-rc.7_biqbaboplfbrettd7655fr4n2y
@@ -81,7 +81,7 @@ importers:
       jest-expect-message: 1.1.3
       jest-image-snapshot: 6.1.0
       mermaid: 9.1.7
-      playwright-chromium: 1.31.2
+      playwright-chromium: 1.32.1
       prettier: 2.8.4
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
@@ -2117,13 +2117,13 @@ packages:
       node-dir: 0.1.17
     dev: true
 
-  /@playwright/test/1.31.2:
-    resolution: {integrity: sha512-BYVutxDI4JeZKV1+ups6dt5WiqKhjBtIYowyZIJ3kBDmJgsuPKsqqKNIMFbUePLSCmp2cZu+BDL427RcNKTRYw==}
+  /@playwright/test/1.32.1:
+    resolution: {integrity: sha512-FTwjCuhlm1qHUGf4hWjfr64UMJD/z0hXYbk+O387Ioe6WdyZQ+0TBDAc6P+pHjx2xCv1VYNgrKbYrNixFWy4Dg==}
     engines: {node: '>=14'}
     hasBin: true
     dependencies:
       '@types/node': 18.15.1
-      playwright-core: 1.31.2
+      playwright-core: 1.32.1
     optionalDependencies:
       fsevents: 2.3.2
     dev: true
@@ -3501,12 +3501,12 @@ packages:
       telejson: 7.0.4
     dev: true
 
-  /@storybook/channel-postmessage/7.0.0-rc.8:
-    resolution: {integrity: sha512-SHx9X5HtNV7/XzcjxzEYFM/3Xxn2pIsNtzFMIpe9YhfMQLGKXgmm9Hv5o5s4GXZquJN6w646XE90eOol6cwTDg==}
+  /@storybook/channel-postmessage/7.0.0-rc.9:
+    resolution: {integrity: sha512-iaEwRN4PvIzxzH8dGXKSKVkepC2+70O6MM4Z+zDOyN1Q6p4grYOddM2Olqdb9cf3TaYES5JENPe5ig62JLu2zg==}
     dependencies:
-      '@storybook/channels': 7.0.0-rc.8
-      '@storybook/client-logger': 7.0.0-rc.8
-      '@storybook/core-events': 7.0.0-rc.8
+      '@storybook/channels': 7.0.0-rc.9
+      '@storybook/client-logger': 7.0.0-rc.9
+      '@storybook/core-events': 7.0.0-rc.9
       '@storybook/global': 5.0.0
       qs: 6.11.1
       telejson: 7.0.4
@@ -3525,8 +3525,8 @@ packages:
     resolution: {integrity: sha512-0D5lKPIa04Hmu9JVd9nuw+1y6RUX/yHva870gX0qB5ts8M8lhfmHlYQLT61kyWcr1/77NIypSUHBuZK5q3E71w==}
     dev: true
 
-  /@storybook/channels/7.0.0-rc.8:
-    resolution: {integrity: sha512-2tI/ECbQcXjncYGLVdrttNT8adIp6kV/bnQGJWmF5hBXZ7Izwyq1WRPTgPT++RihmOOTHvkRx4GCKfwluOrNpA==}
+  /@storybook/channels/7.0.0-rc.9:
+    resolution: {integrity: sha512-XqgHzEqAlNG9lfNjYTLepXQNafoD7cUSDSFbZkpOAUlYRsBz0cyhCGyxAWDyH7er8ZJCCIfxsEwZVaMGg9bLFQ==}
     dev: true
 
   /@storybook/cli/7.0.0-rc.7:
@@ -3584,8 +3584,8 @@ packages:
       '@storybook/global': 5.0.0
     dev: true
 
-  /@storybook/client-logger/7.0.0-rc.8:
-    resolution: {integrity: sha512-6pBwnK0vB0mgkO8opiHbZxBVGyaKFSpJXglfx8F15gIwA3r1njgtOZvvYx+03DCz0ExaTiSXrrbWp39mI8mo5w==}
+  /@storybook/client-logger/7.0.0-rc.9:
+    resolution: {integrity: sha512-ihBDLgfECGXaP54KXMcTLokOXdKryoKSF6UEErJpzb/Foq8g/OQSaklSjx0xdoEt01JT+cJEdQOLAewNK/4fYg==}
     dependencies:
       '@storybook/global': 5.0.0
     dev: true
@@ -3671,8 +3671,8 @@ packages:
     resolution: {integrity: sha512-gwAbDlH/UdLIR/CJQaZr4bS6IgHVI0W9JBELnIubfFzAEH5aiRupvywpWFuFh1/Z1IEnykyq7BaNChfw0rFvcw==}
     dev: true
 
-  /@storybook/core-events/7.0.0-rc.8:
-    resolution: {integrity: sha512-KsKf+Ob6zQ8+IJ9oDD5xqASwYGzcjT08azBjSt4yocHIJ3mY741h88YDS0wcwnM+JrV6iFYlY0hiK35lnBEddA==}
+  /@storybook/core-events/7.0.0-rc.9:
+    resolution: {integrity: sha512-FDEDaaksKJFGeaME1lnxwQr7AQxBFZoPJD8jX9t5hniFtouJ7Pdn8lGDueJME2XNuklT4VZHAUwFVO3WcbxbzA==}
     dev: true
 
   /@storybook/core-server/7.0.0-rc.7:
@@ -3791,14 +3791,14 @@ packages:
       '@storybook/preview-api': 7.0.0-rc.7
     dev: true
 
-  /@storybook/instrumenter/7.0.0-rc.8:
-    resolution: {integrity: sha512-esRTjLLJJAKsTun/8u/wvsS+OPlwB2eal+ZAo0cBo+YTpkw0A6R+HunhNU1elZ8ztbJsZxP2drPprrFGXgeaLQ==}
+  /@storybook/instrumenter/7.0.0-rc.9:
+    resolution: {integrity: sha512-Uyq4ZjuEcG7ThZqq4L0YsGX5LnbP85yi25k+1ySkr677eft0VpTp5U37jmyChGkoI03kghVNvM16LTgVuQ83kw==}
     dependencies:
-      '@storybook/channels': 7.0.0-rc.8
-      '@storybook/client-logger': 7.0.0-rc.8
-      '@storybook/core-events': 7.0.0-rc.8
+      '@storybook/channels': 7.0.0-rc.9
+      '@storybook/client-logger': 7.0.0-rc.9
+      '@storybook/core-events': 7.0.0-rc.9
       '@storybook/global': 5.0.0
-      '@storybook/preview-api': 7.0.0-rc.8
+      '@storybook/preview-api': 7.0.0-rc.9
     dev: true
 
   /@storybook/manager-api/7.0.0-rc.7_biqbaboplfbrettd7655fr4n2y:
@@ -3873,22 +3873,21 @@ packages:
       util-deprecate: 1.0.2
     dev: true
 
-  /@storybook/preview-api/7.0.0-rc.8:
-    resolution: {integrity: sha512-K45I81s2ZOoeAmKC8DP0HPhR67tr94pkgKddaoWLQJHBgVq9GKuy7QCcnn2zYKOFd1d/uqcnrQyg4AkmcjkVCg==}
+  /@storybook/preview-api/7.0.0-rc.9:
+    resolution: {integrity: sha512-KcbqKm4Ge0G8iZNzCnIzGKY7ZD4L6140BQexid0t6dDvBRGavkUXvg3IH+nzXFTHW4H9lW3yFY3zbPANjUexXw==}
     dependencies:
-      '@storybook/channel-postmessage': 7.0.0-rc.8
-      '@storybook/channels': 7.0.0-rc.8
-      '@storybook/client-logger': 7.0.0-rc.8
-      '@storybook/core-events': 7.0.0-rc.8
+      '@storybook/channel-postmessage': 7.0.0-rc.9
+      '@storybook/channels': 7.0.0-rc.9
+      '@storybook/client-logger': 7.0.0-rc.9
+      '@storybook/core-events': 7.0.0-rc.9
       '@storybook/csf': 0.0.2-next.10
       '@storybook/global': 5.0.0
-      '@storybook/types': 7.0.0-rc.8
+      '@storybook/types': 7.0.0-rc.9
       '@types/qs': 6.9.7
       dequal: 2.0.3
       lodash: 4.17.21
       memoizerific: 1.11.3
       qs: 6.11.1
-      slash: 3.0.0
       synchronous-promise: 2.0.17
       ts-dedent: 2.2.0
       util-deprecate: 1.0.2
@@ -3951,8 +3950,8 @@ packages:
   /@storybook/testing-library/0.0.14-next.1:
     resolution: {integrity: sha512-1CAl40IKIhcPaCC4pYCG0b9IiYNymktfV/jTrX7ctquRY3akaN7f4A1SippVHosksft0M+rQTFE0ccfWW581fw==}
     dependencies:
-      '@storybook/client-logger': 7.0.0-rc.8
-      '@storybook/instrumenter': 7.0.0-rc.8
+      '@storybook/client-logger': 7.0.0-rc.9
+      '@storybook/instrumenter': 7.0.0-rc.9
       '@testing-library/dom': 8.20.0
       '@testing-library/user-event': 13.5.0_yxlyej73nftwmh2fiao7paxmlm
       ts-dedent: 2.2.0
@@ -3986,10 +3985,10 @@ packages:
       file-system-cache: 2.0.2
     dev: true
 
-  /@storybook/types/7.0.0-rc.8:
-    resolution: {integrity: sha512-Jz3MLLKs+Jy8dZVd+HVHuKAbxa7xcF/MLfUNldu0HxtJr3b7ybUlvjWjT5h2I60V5TYkWGf9wcKmegI6TGiJXQ==}
+  /@storybook/types/7.0.0-rc.9:
+    resolution: {integrity: sha512-fnlEM+p1h8KAESKa0g+JK6FC5pwS6rci+vG1TexzMWPyk87bJeqZb7aFhhhd5t7UK5CQnZjka9t8RXD7atXk7A==}
     dependencies:
-      '@storybook/channels': 7.0.0-rc.8
+      '@storybook/channels': 7.0.0-rc.9
       '@types/babel__core': 7.20.0
       '@types/express': 4.17.17
       file-system-cache: 2.0.2
@@ -10177,17 +10176,17 @@ packages:
       - supports-color
     dev: true
 
-  /playwright-chromium/1.31.2:
-    resolution: {integrity: sha512-De3FSR5C5PUpyv6d7eZbOPGbG4opgjgLGKaNOyR/QN8gfiVQxZpudP1hJp0S/zPnP5W6qirohgqsjLFYLPVJlw==}
+  /playwright-chromium/1.32.1:
+    resolution: {integrity: sha512-TADlQ5xJ4iHIHLKQw361PrleUMHJIRlrw+yDadd3IWS0TCHL+CpMjGhSV9OZbKdsi0oZxjDudwd8B2d6lzjfmw==}
     engines: {node: '>=14'}
     hasBin: true
     requiresBuild: true
     dependencies:
-      playwright-core: 1.31.2
+      playwright-core: 1.32.1
     dev: true
 
-  /playwright-core/1.31.2:
-    resolution: {integrity: sha512-a1dFgCNQw4vCsG7bnojZjDnPewZcw7tZUNFN0ZkcLYKj+mPmXvg4MpaaKZ5SgqPsOmqIf2YsVRkgqiRDxD+fDQ==}
+  /playwright-core/1.32.1:
+    resolution: {integrity: sha512-KZYUQC10mXD2Am1rGlidaalNGYk3LU1vZqqNk0gT4XPty1jOqgup8KDP8l2CUlqoNKhXM5IfGjWgW37xvGllBA==}
     engines: {node: '>=14'}
     hasBin: true
     dev: true


### PR DESCRIPTION
This PR:
 - upgrades Playwright (& Chrome) (debugging issues in the main pipeline)
 - temporarly adds `add-apt-repository` to the `checkout-install` action due to differences between ubuntu-`latest:20230326.2` (broken) and `latest:20230317.1` (working)
 - fixes skipped test