### PR TITLE
DX-335 - Prepare release #1 (deactivate release #2)

### DIFF
--- a/.github/scripts/embed.sh
+++ b/.github/scripts/embed.sh
@@ -51,13 +51,13 @@ fi
  --dst docs/v6.3 \
  --org ${ORG_DOCS_63:-shopware}
 
-./docs-cli clone \
- --ci \
- --repository shopware/frontends \
- --branch ${BRANCH_FRONTENDS:-main} \
- --src apps/docs/src \
- --dst frontends \
- --org ${ORG_FRONTENDS:-shopware}
+#./docs-cli clone \
+# --ci \
+# --repository shopware/frontends \
+# --branch ${BRANCH_FRONTENDS:-main} \
+# --src apps/docs/src \
+# --dst frontends \
+# --org ${ORG_FRONTENDS:-shopware}
 
 #./docs-cli clone \
 # --ci \
@@ -69,26 +69,26 @@ fi
 # --dst frontends-gl \
 # --git gitlab.shopware.com
 
-./docs-cli clone \
- --ci \
- --repository shopware/admin-extension-sdk \
- --branch ${BRANCH_ADMIN_EXTENSION_SDK:-main} \
- --src docs/docs/guide \
- --dst resources/admin-extension-sdk \
- --org ${ORG_ADMIN_EXTENSION_SDK:-shopware}
+#./docs-cli clone \
+# --ci \
+# --repository shopware/admin-extension-sdk \
+# --branch ${BRANCH_ADMIN_EXTENSION_SDK:-main} \
+# --src docs/docs/guide \
+# --dst resources/admin-extension-sdk \
+# --org ${ORG_ADMIN_EXTENSION_SDK:-shopware}
 
-./docs-cli clone \
- --ci \
- --repository shopware/meteor-icon-kit \
- --branch ${BRANCH_METEOR_ICON_KIT:-main} \
- --src docs \
- --dst resources/meteor-icon-kit \
- --org ${ORG_METEOR_ICON_KIT:-shopware}
+#./docs-cli clone \
+# --ci \
+# --repository shopware/meteor-icon-kit \
+# --branch ${BRANCH_METEOR_ICON_KIT:-main} \
+# --src docs \
+# --dst resources/meteor-icon-kit \
+# --org ${ORG_METEOR_ICON_KIT:-shopware}
 
-./docs-cli clone \
- --ci \
- --repository shopware/meteor-component-library \
- --branch ${BRANCH_METEOR_COMPONENT_LIBRARY:-main} \
- --src docs \
- --dst resources/meteor-component-library \
- --org ${ORG_METEOR_COMPONENT_LIBRARY:-shopware}
+#./docs-cli clone \
+# --ci \
+# --repository shopware/meteor-component-library \
+# --branch ${BRANCH_METEOR_COMPONENT_LIBRARY:-main} \
+# --src docs \
+# --dst resources/meteor-component-library \
+# --org ${ORG_METEOR_COMPONENT_LIBRARY:-shopware}

--- a/.github/workflows/checkout-test-build-deploy.yml
+++ b/.github/workflows/checkout-test-build-deploy.yml
@@ -162,9 +162,9 @@ jobs:
           export NODE_OPTIONS="--max-old-space-size=8096"
           pnpm run build
 
-      - name: Zip externals
-        run: |
-          cd external && zip -r db-external.zip * -i '*.md'
+      #- name: Zip externals
+      #  run: |
+      #    cd external && zip -r db-external.zip * -i '*.md'
 
       - name: Zip folder
         run: zip -r full-build.zip .vitepress/dist/
@@ -176,12 +176,12 @@ jobs:
           name: full-build-${{ github.sha }}
           path: full-build.zip
 
-      - name: Upload external
-        uses: actions/upload-artifact@v3
-        with:
-          if-no-files-found: error
-          name: db-external-${{ github.sha }}
-          path: external/db-external.zip
+      #- name: Upload external
+      #  uses: actions/upload-artifact@v3
+      #  with:
+      #    if-no-files-found: error
+      #    name: db-external-${{ github.sha }}
+      #    path: external/db-external.zip
 
   chromatic:
     name: Deploy Storybook to Chromatic
@@ -263,15 +263,15 @@ jobs:
         with:
           name: db-index-${{ github.sha }}
 
-      - uses: actions/download-artifact@v3
-        with:
-          name: db-external-${{ github.sha }}
+      #- uses: actions/download-artifact@v3
+      #  with:
+      #    name: db-external-${{ github.sha }}
 
       - name: Merge base and external sources
         run: |
           mkdir merged
           unzip -o db-index.zip -d merged
-          unzip -o db-external.zip -d merged
+          true || unzip -o db-external.zip -d merged
           zip -r db-merged.zip merged/ 
 
       - name: Send artifact

--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -137,7 +137,7 @@ export default defineConfigWithTheme<ThemeConfig>({
     /**
      * Fetch Stoplight URLs.
      */
-    const stoplightUrls = [
+    /*const stoplightUrls = [
       ...await getStoplightUrls({
         source: 'https://shopware.stoplight.io/api/v1/projects/cHJqOjEwNjA0NQ/table-of-contents',
         prefix: '/resources/api/store-api-reference.html#/',
@@ -146,31 +146,31 @@ export default defineConfigWithTheme<ThemeConfig>({
         source: 'https://shopware.stoplight.io/api/v1/projects/cHJqOjEwNjA0Mw/table-of-contents',
         prefix: '/resources/api/admin-api-reference.html#/',
       }),
-    ];
+    ];*/
 
     /**
      * Create public sitemap.xml.
      */
-    await createSitemap(stoplightUrls);
+    await createSitemap(/*stoplightUrls*/);
 
     /**
      * Transform Store API JSON reference to Markdown for Knowledge base.
      */
-    await generateMarkdownFromStoplight({
+    /*await generateMarkdownFromStoplight({
       source: 'https://shopware.stoplight.io/api/v1/projects/cHJqOjEwNjA0NQ/table-of-contents',
       nodes: 'https://shopware.stoplight.io/api/v1/workspaces/d2s6MzM5MTQ/nodes?project_ids[0]=cHJqOjEwNjA0NQ',
       reference: 'https://raw.githubusercontent.com/shopware/store-api-reference/main/storeapi.json',
       as: 'resources/api/admin-api-reference.html',
-    });
+    });*/
 
     /**
      * Transform Admin API JSON reference to Markdown for Knowledge base.
      */
-    await generateMarkdownFromStoplight({
+    /*await generateMarkdownFromStoplight({
       source: 'https://shopware.stoplight.io/api/v1/projects/cHJqOjEwNjA0Mw/table-of-contents',
       nodes: 'https://shopware.stoplight.io/api/v1/workspaces/d2s6MzM5MTQ/nodes?project_ids[0]=cHJqOjEwNjA0Mw',
       reference: 'https://raw.githubusercontent.com/shopware/admin-api-reference/main/storeapi.json',
       as: 'resources/api/store-api-reference.html',
-    }, false);
+    }, false);*/
   }
 });

--- a/.vitepress/navigation.ts
+++ b/.vitepress/navigation.ts
@@ -59,7 +59,8 @@ const navigation = buildSidebarNav('./src/', [
                     },
                     {
                         text: "Meteor Icon Kit",
-                        link: "/resources/meteor-icon-kit/",
+                        //link: "/resources/meteor-icon-kit/",
+                        link: 'https://shopware.github.io/meteor-icon-kit/',
                         repo: 'shopware/meteor-icon-kit',
                     },
                     {

--- a/.vitepress/navigation.ts
+++ b/.vitepress/navigation.ts
@@ -2,10 +2,6 @@ import {buildSidebarNav} from "../node_modules/vitepress-shopware-docs/src/core/
 
 const navigation = buildSidebarNav('./src/', [
     {
-        link: '/docs/',
-        text: 'Docs',
-    },
-    {
         // link: '/apps/',
         link: '/docs/guides/plugins/apps/',
         text: 'Apps',
@@ -14,10 +10,6 @@ const navigation = buildSidebarNav('./src/', [
         //link: '/themes/',
         link: '/docs/guides/plugins/themes/',
         text: 'Themes',
-    },
-    {
-        link: '/docs/guides/plugins/plugins/',
-        text: 'Plugins',
     },
     {
         //link: '/frontends/',

--- a/.vitepress/navigation.ts
+++ b/.vitepress/navigation.ts
@@ -20,7 +20,8 @@ const navigation = buildSidebarNav('./src/', [
         text: 'Plugins',
     },
     {
-        link: '/frontends/',
+        //link: '/frontends/',
+        link: 'https://shopware-frontends-docs.vercel.app/',
         text: 'Frontends',
         repo: 'shopware/frontends',
     },

--- a/.vitepress/navigation.ts
+++ b/.vitepress/navigation.ts
@@ -90,8 +90,8 @@ const navigation = buildSidebarNav('./src/', [
     '/docs/',
     '/docs/v6.4/',
     '/docs/v6.3/',
-    '/resources/admin-extension-sdk/',
-    '/resources/meteor-component-library/',
+    //'/resources/admin-extension-sdk/',
+    //'/resources/meteor-component-library/',
     '/apps/', // custom, tmp!
 ]);
 

--- a/.vitepress/navigation.ts
+++ b/.vitepress/navigation.ts
@@ -37,12 +37,14 @@ const navigation = buildSidebarNav('./src/', [
                 items: [
                     {
                         text: "Store API",
-                        link: "/resources/api/store-api-reference",
+                        // link: "/resources/api/store-api-reference",
+                        link: 'https://shopware.stoplight.io/docs/store-api/',
                         repo: 'shopware/store-api-reference',
                     },
                     {
                         text: "Admin API",
-                        link: "/resources/api/admin-api-reference",
+                        //link: "/resources/api/admin-api-reference",
+                        link: 'https://shopware.stoplight.io/docs/admin-api/',
                         repo: 'shopware/admin-api-reference',
                     }
                 ]

--- a/__tests__/cli/command/embed.test.ts
+++ b/__tests__/cli/command/embed.test.ts
@@ -51,17 +51,20 @@ describe('cli embed', async () => {
 
         expect(result.stdout).toContain('Embedding repositories');
 
-        expect(result.stdout).toContain('Embedding shopware/frontends');
-        expect(result.stdout).toContain('Processed shopware/frontends');
+        expect(result.stdout).toContain('Embedding shopware/docs');
+        expect(result.stdout).toContain('Processed shopware/docs');
 
-        expect(result.stdout).toContain('Embedding shopware/admin-extension-sdk');
-        expect(result.stdout).toContain('Processed shopware/admin-extension-sdk');
+        //expect(result.stdout).toContain('Embedding shopware/frontends');
+        //expect(result.stdout).toContain('Processed shopware/frontends');
 
-        expect(result.stdout).toContain('Embedding shopware/meteor-icon-kit');
-        expect(result.stdout).toContain('Processed shopware/meteor-icon-kit');
+        //expect(result.stdout).toContain('Embedding shopware/admin-extension-sdk');
+        //expect(result.stdout).toContain('Processed shopware/admin-extension-sdk');
 
-        expect(result.stdout).toContain('Embedding shopware/meteor-component-library');
-        expect(result.stdout).toContain('Processed shopware/meteor-component-library');
+        //expect(result.stdout).toContain('Embedding shopware/meteor-icon-kit');
+        //expect(result.stdout).toContain('Processed shopware/meteor-icon-kit');
+
+        //expect(result.stdout).toContain('Embedding shopware/meteor-component-library');
+        //expect(result.stdout).toContain('Processed shopware/meteor-component-library');
 
         expect(result.stdout).toContain('Running additional steps');
         expect(result.stdout).toContain('Repositories embedded');

--- a/__tests__/cli/command/embed.test.ts
+++ b/__tests__/cli/command/embed.test.ts
@@ -66,7 +66,8 @@ describe('cli embed', async () => {
         //expect(result.stdout).toContain('Embedding shopware/meteor-component-library');
         //expect(result.stdout).toContain('Processed shopware/meteor-component-library');
 
-        expect(result.stdout).toContain('Running additional steps');
+        //expect(result.stdout).toContain('Running additional steps');
+
         expect(result.stdout).toContain('Repositories embedded');
         // long-running
     }, timeout.high.timeout);

--- a/__tests__/e2e/admin-extension-sdk/index.test.ts
+++ b/__tests__/e2e/admin-extension-sdk/index.test.ts
@@ -1,6 +1,6 @@
 import {Embedded} from "../page-objects/embedded";
 
-describe('render correct content', async () => {
+describe.skip('render correct content', async () => {
     let embeddedPage: Embedded;
 
     beforeAll(async () => {

--- a/__tests__/e2e/frontends/index.test.ts
+++ b/__tests__/e2e/frontends/index.test.ts
@@ -1,6 +1,6 @@
 import {Embedded} from "../page-objects/embedded";
 
-describe('render correct content', async () => {
+describe.skip('render correct content', async () => {
     let embeddedPage: Embedded;
 
     beforeAll(async () => {

--- a/__tests__/e2e/index.test.ts
+++ b/__tests__/e2e/index.test.ts
@@ -6,7 +6,7 @@ describe('render correct content', async () => {
     test('navigation', async() => {
         const navBarLocator = page.locator('.VPNavBarMenu > .VPNavBarMenuLink');
         const links = await navBarLocator.allTextContents()
-        expect(links).toEqual(['Docs', 'Apps', 'Themes', 'Plugins', 'Frontends', 'Integrations'])
+        expect(links).toEqual(['Apps', 'Themes', 'Frontends', 'Integrations'])
 
         const subNavBarLocator = page.locator('.VPNavBarMenu > .VPNavBarMenuGroup .vt-flyout-button-text');
         const groupLinks = await subNavBarLocator.allTextContents()

--- a/__tests__/e2e/meteor-component-library/index.test.ts
+++ b/__tests__/e2e/meteor-component-library/index.test.ts
@@ -1,6 +1,6 @@
 import {Embedded} from "../page-objects/embedded";
 
-describe('render correct content', async () => {
+describe.skip('render correct content', async () => {
     let embeddedPage: Embedded;
 
     beforeAll(async () => {

--- a/__tests__/e2e/meteor-icon-kit/index.test.ts
+++ b/__tests__/e2e/meteor-icon-kit/index.test.ts
@@ -1,7 +1,7 @@
 import {Embedded} from "../page-objects/embedded";
 import {eachLocator} from "../utils/locator";
 
-describe('render correct content', async () => {
+describe.skip('render correct content', async () => {
     let embeddedPage: Embedded;
     const fourOhFour = [];
 

--- a/cli/src/commands/embed.ts
+++ b/cli/src/commands/embed.ts
@@ -33,6 +33,10 @@ export default {
                 continue;
             }
 
+            if (!configure && repo.skip) {
+                continue;
+            }
+
             output.notice(`Processing ${repo.name}`);
             await cloneCustom(repo, configure, ci);
         }

--- a/cli/src/data.ts
+++ b/cli/src/data.ts
@@ -28,6 +28,7 @@ export const repositories = [
         dst: 'frontends',
         branch: env.BRANCH_FRONTENDS || 'main',
         org: env.ORG_FRONTENDS || 'shopware',
+        skip: true,
     },
     {
         name: 'gitlab.shopware.com/product/engineering/platform-group/pwa/frontends',
@@ -45,6 +46,7 @@ export const repositories = [
                 description: 'GitLab deploy key'
             },
         },
+        skip: true,
     },
     {
         name: 'shopware/admin-extension-sdk',
@@ -52,6 +54,7 @@ export const repositories = [
         dst: 'resources/admin-extension-sdk',
         branch: env.BRANCH_ADMIN_EXTENSION_SDK || 'DX-223' || 'main',
         org: env.ORG_ADMIN_EXTENSION_SDK || 'shopware',
+        skip: true,
     },
     {
         name: 'shopware/meteor-icon-kit',
@@ -67,6 +70,7 @@ export const repositories = [
                 description: 'Figma API key'
             },
         },
+        skip: true,
     },
     {
         name: 'shopware/meteor-component-library',
@@ -74,5 +78,6 @@ export const repositories = [
         dst: 'resources/meteor-component-library',
         branch: env.BRANCH_METEOR_COMPONENT_LIBRARY || 'DX-231' || 'main',
         org: env.ORG_METEOR_COMPONENT_LIBRARY || 'bojanrajh',
+        skip: true,
     }
 ];

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "terser": "^5.16.6",
     "vitepress": "1.0.0-alpha.63",
-    "vitepress-shopware-docs": "0.3.0-beta.36",
+    "vitepress-shopware-docs": "0.3.0-beta.37",
     "vue": "^3.2.47"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,13 +46,13 @@ importers:
       uuid: ^9.0.0
       vite-plugin-inspect: ^0.7.16
       vitepress: 1.0.0-alpha.63
-      vitepress-shopware-docs: 0.3.0-beta.36
+      vitepress-shopware-docs: 0.3.0-beta.37
       vitest: ^0.28.5
       vue: ^3.2.47
     dependencies:
       terser: 5.16.6
       vitepress: 1.0.0-alpha.63_dbqooz3m3qpdoofqkclhuyaywu
-      vitepress-shopware-docs: 0.3.0-beta.36_nmj5hrc277vwxcagfboopqgrjq
+      vitepress-shopware-docs: 0.3.0-beta.37_nmj5hrc277vwxcagfboopqgrjq
       vue: 3.2.47
     devDependencies:
       '@originjs/vite-plugin-require-context': 1.0.9
@@ -2235,7 +2235,7 @@ packages:
       react:
         optional: true
     dependencies:
-      '@react-types/shared': 3.9.0_react@18.2.0
+      '@react-types/shared': 3.17.0_react@18.2.0
       react: 18.2.0
     dev: false
 
@@ -2259,7 +2259,7 @@ packages:
       react:
         optional: true
     dependencies:
-      '@react-types/shared': 3.9.0_react@18.2.0
+      '@react-types/shared': 3.17.0_react@18.2.0
       react: 18.2.0
     dev: false
 
@@ -2294,7 +2294,7 @@ packages:
         optional: true
     dependencies:
       '@react-types/checkbox': 3.4.2_react@18.2.0
-      '@react-types/shared': 3.9.0_react@18.2.0
+      '@react-types/shared': 3.17.0_react@18.2.0
       react: 18.2.0
     dev: false
 
@@ -2306,7 +2306,7 @@ packages:
       react:
         optional: true
     dependencies:
-      '@react-types/shared': 3.9.0_react@18.2.0
+      '@react-types/shared': 3.17.0_react@18.2.0
       react: 18.2.0
     dev: false
 
@@ -3180,7 +3180,7 @@ packages:
       '@storybook/csf-plugin': 7.0.0-rc.7
       '@storybook/csf-tools': 7.0.0-rc.7
       '@storybook/global': 5.0.0
-      '@storybook/mdx2-csf': 1.0.0-next.6
+      '@storybook/mdx2-csf': 1.0.0-next.8
       '@storybook/node-logger': 7.0.0-rc.7
       '@storybook/postinstall': 7.0.0-rc.7
       '@storybook/preview-api': 7.0.0-rc.7
@@ -3280,7 +3280,7 @@ packages:
     dependencies:
       '@storybook/client-logger': 7.0.0-rc.7
       '@storybook/core-events': 7.0.0-rc.7
-      '@storybook/csf': 0.0.2-next.10
+      '@storybook/csf': 0.0.2-next.11
       '@storybook/global': 5.0.0
       '@storybook/manager-api': 7.0.0-rc.7_biqbaboplfbrettd7655fr4n2y
       '@storybook/preview-api': 7.0.0-rc.7
@@ -3396,7 +3396,7 @@ packages:
       '@storybook/client-logger': 7.0.0-rc.7
       '@storybook/components': 7.0.0-rc.7_biqbaboplfbrettd7655fr4n2y
       '@storybook/core-events': 7.0.0-rc.7
-      '@storybook/csf': 0.0.2-next.10
+      '@storybook/csf': 0.0.2-next.11
       '@storybook/docs-tools': 7.0.0-rc.7
       '@storybook/global': 5.0.0
       '@storybook/manager-api': 7.0.0-rc.7_biqbaboplfbrettd7655fr4n2y
@@ -3469,7 +3469,7 @@ packages:
       '@storybook/client-logger': 7.0.0-rc.7
       '@storybook/core-common': 7.0.0-rc.7
       '@storybook/csf-plugin': 7.0.0-rc.7
-      '@storybook/mdx2-csf': 1.0.0-next.6
+      '@storybook/mdx2-csf': 1.0.0-next.8
       '@storybook/node-logger': 7.0.0-rc.7
       '@storybook/preview': 7.0.0-rc.7
       '@storybook/preview-api': 7.0.0-rc.7
@@ -3499,12 +3499,12 @@ packages:
       telejson: 7.0.4
     dev: true
 
-  /@storybook/channel-postmessage/7.0.0-rc.9:
-    resolution: {integrity: sha512-iaEwRN4PvIzxzH8dGXKSKVkepC2+70O6MM4Z+zDOyN1Q6p4grYOddM2Olqdb9cf3TaYES5JENPe5ig62JLu2zg==}
+  /@storybook/channel-postmessage/7.0.1:
+    resolution: {integrity: sha512-wcJfnq49PwqKhfMJciDCJ1P5YcpN43gj9MLXIEprq7escegiM4YHBeOHCsu/YZnaE7pLnYRSxqCoy/MpWZPbIQ==}
     dependencies:
-      '@storybook/channels': 7.0.0-rc.9
-      '@storybook/client-logger': 7.0.0-rc.9
-      '@storybook/core-events': 7.0.0-rc.9
+      '@storybook/channels': 7.0.1
+      '@storybook/client-logger': 7.0.1
+      '@storybook/core-events': 7.0.1
       '@storybook/global': 5.0.0
       qs: 6.11.1
       telejson: 7.0.4
@@ -3523,8 +3523,8 @@ packages:
     resolution: {integrity: sha512-0D5lKPIa04Hmu9JVd9nuw+1y6RUX/yHva870gX0qB5ts8M8lhfmHlYQLT61kyWcr1/77NIypSUHBuZK5q3E71w==}
     dev: true
 
-  /@storybook/channels/7.0.0-rc.9:
-    resolution: {integrity: sha512-XqgHzEqAlNG9lfNjYTLepXQNafoD7cUSDSFbZkpOAUlYRsBz0cyhCGyxAWDyH7er8ZJCCIfxsEwZVaMGg9bLFQ==}
+  /@storybook/channels/7.0.1:
+    resolution: {integrity: sha512-Hm/vrCkpxvZRIIjs9vwLDvK4TVINj8E3xRBPq29qUs/kdpf3f8+NiYd/gRXN+JNH7Ov1NC4L5khlR1rXh5AUNQ==}
     dev: true
 
   /@storybook/cli/7.0.0-rc.7:
@@ -3582,8 +3582,8 @@ packages:
       '@storybook/global': 5.0.0
     dev: true
 
-  /@storybook/client-logger/7.0.0-rc.9:
-    resolution: {integrity: sha512-ihBDLgfECGXaP54KXMcTLokOXdKryoKSF6UEErJpzb/Foq8g/OQSaklSjx0xdoEt01JT+cJEdQOLAewNK/4fYg==}
+  /@storybook/client-logger/7.0.1:
+    resolution: {integrity: sha512-yR8tGywLSTY/cmCae9yCmo6CzU+F4QAzA2RqgKRHpM44LHjsD1rG3wQxnBa5cZs7/zopMKYK1Bt7xhp/dSS56g==}
     dependencies:
       '@storybook/global': 5.0.0
     dev: true
@@ -3594,7 +3594,7 @@ packages:
       '@babel/core': 7.21.3
       '@babel/preset-env': 7.20.2_@babel+core@7.21.3
       '@babel/types': 7.21.3
-      '@storybook/csf': 0.0.2-next.10
+      '@storybook/csf': 0.0.2-next.11
       '@storybook/csf-tools': 7.0.0-rc.7
       '@storybook/node-logger': 7.0.0-rc.7
       '@storybook/types': 7.0.0-rc.7
@@ -3620,7 +3620,7 @@ packages:
         optional: true
     dependencies:
       '@storybook/client-logger': 7.0.0-rc.7
-      '@storybook/csf': 0.0.2-next.10
+      '@storybook/csf': 0.0.2-next.11
       '@storybook/global': 5.0.0
       '@storybook/theming': 7.0.0-rc.7_biqbaboplfbrettd7655fr4n2y
       '@storybook/types': 7.0.0-rc.7
@@ -3669,8 +3669,8 @@ packages:
     resolution: {integrity: sha512-gwAbDlH/UdLIR/CJQaZr4bS6IgHVI0W9JBELnIubfFzAEH5aiRupvywpWFuFh1/Z1IEnykyq7BaNChfw0rFvcw==}
     dev: true
 
-  /@storybook/core-events/7.0.0-rc.9:
-    resolution: {integrity: sha512-FDEDaaksKJFGeaME1lnxwQr7AQxBFZoPJD8jX9t5hniFtouJ7Pdn8lGDueJME2XNuklT4VZHAUwFVO3WcbxbzA==}
+  /@storybook/core-events/7.0.1:
+    resolution: {integrity: sha512-Q3wBHoahO5d7Zm0S0zvXIqnG/fuf02RNMjTiAMYG55MlPZEmu3ll4VzDtroeku4Zwo9xbHGxgVQH5LFScQncEQ==}
     dev: true
 
   /@storybook/core-server/7.0.0-rc.7:
@@ -3681,9 +3681,9 @@ packages:
       '@storybook/builder-manager': 7.0.0-rc.7
       '@storybook/core-common': 7.0.0-rc.7
       '@storybook/core-events': 7.0.0-rc.7
-      '@storybook/csf': 0.0.2-next.10
+      '@storybook/csf': 0.0.2-next.11
       '@storybook/csf-tools': 7.0.0-rc.7
-      '@storybook/docs-mdx': 0.0.1-next.6
+      '@storybook/docs-mdx': 0.0.1-next.7
       '@storybook/global': 5.0.0
       '@storybook/manager': 7.0.0-rc.7
       '@storybook/node-logger': 7.0.0-rc.7
@@ -3742,7 +3742,7 @@ packages:
       '@babel/parser': 7.21.3
       '@babel/traverse': 7.21.3
       '@babel/types': 7.21.3
-      '@storybook/csf': 0.0.2-next.10
+      '@storybook/csf': 0.0.2-next.11
       '@storybook/types': 7.0.0-rc.7
       fs-extra: 11.1.0
       recast: 0.23.1
@@ -3751,14 +3751,20 @@ packages:
       - supports-color
     dev: true
 
-  /@storybook/csf/0.0.2-next.10:
-    resolution: {integrity: sha512-m2PFgBP/xRIF85VrDhvesn9ktaD2pN3VUjvMqkAL/cINp/3qXsCyI81uw7N5VEOkQAbWrY2FcydnvEPDEdE8fA==}
+  /@storybook/csf/0.0.2-next.11:
+    resolution: {integrity: sha512-xGt0YSVxZb43sKmEf1GIQD8xEbo+c+S6khDEL7Qu/pYA0gh5z3WUuhOlovnelYj/YJod+XRsfVvk23AaRfUJ4Q==}
     dependencies:
       type-fest: 2.19.0
     dev: true
 
-  /@storybook/docs-mdx/0.0.1-next.6:
-    resolution: {integrity: sha512-DjoSIXADmLJtdroXAjUotFiZlcZ2usWhqrS7aeOtZs0DVR0Ws5WQjnwtpDUXt8gryTSd+OZJ0cNsDcqg4JDEvQ==}
+  /@storybook/csf/0.1.0:
+    resolution: {integrity: sha512-uk+jMXCZ8t38jSTHk2o5btI+aV2Ksbvl6DoOv3r6VaCM1KZqeuMwtwywIQdflkA8/6q/dKT8z8L+g8hC4GC3VQ==}
+    dependencies:
+      type-fest: 2.19.0
+    dev: true
+
+  /@storybook/docs-mdx/0.0.1-next.7:
+    resolution: {integrity: sha512-JbgBf/EMBtx65iXtB3pOiX3818UeL9jZ+KAY241OAPqJVXjMQ5KaVOdg/57MSmd508HDIGx7CiImOMEmWwQ9/g==}
     dev: true
 
   /@storybook/docs-tools/7.0.0-rc.7:
@@ -3789,14 +3795,14 @@ packages:
       '@storybook/preview-api': 7.0.0-rc.7
     dev: true
 
-  /@storybook/instrumenter/7.0.0-rc.9:
-    resolution: {integrity: sha512-Uyq4ZjuEcG7ThZqq4L0YsGX5LnbP85yi25k+1ySkr677eft0VpTp5U37jmyChGkoI03kghVNvM16LTgVuQ83kw==}
+  /@storybook/instrumenter/7.0.1:
+    resolution: {integrity: sha512-QeM4Jkib9/2KwPiw1dPlvwJ6ld9AZCweeKAH+uQg2BiU4qPINg6SGFoa2SwLxviZZzsMjAU/XvUei1BW2QLaow==}
     dependencies:
-      '@storybook/channels': 7.0.0-rc.9
-      '@storybook/client-logger': 7.0.0-rc.9
-      '@storybook/core-events': 7.0.0-rc.9
+      '@storybook/channels': 7.0.1
+      '@storybook/client-logger': 7.0.1
+      '@storybook/core-events': 7.0.1
       '@storybook/global': 5.0.0
-      '@storybook/preview-api': 7.0.0-rc.9
+      '@storybook/preview-api': 7.0.1
     dev: true
 
   /@storybook/manager-api/7.0.0-rc.7_biqbaboplfbrettd7655fr4n2y:
@@ -3813,7 +3819,7 @@ packages:
       '@storybook/channels': 7.0.0-rc.7
       '@storybook/client-logger': 7.0.0-rc.7
       '@storybook/core-events': 7.0.0-rc.7
-      '@storybook/csf': 0.0.2-next.10
+      '@storybook/csf': 0.0.2-next.11
       '@storybook/global': 5.0.0
       '@storybook/router': 7.0.0-rc.7_biqbaboplfbrettd7655fr4n2y
       '@storybook/theming': 7.0.0-rc.7_biqbaboplfbrettd7655fr4n2y
@@ -3833,8 +3839,8 @@ packages:
     resolution: {integrity: sha512-Qbw7rGxLEw/YWCpE3tC0Hnk5y7RDs/0uI9yx05vIg5z1UmMooO8yrwsuyHb0nYMtx94WDk5Zg9Jb426ZyUfxJg==}
     dev: true
 
-  /@storybook/mdx2-csf/1.0.0-next.6:
-    resolution: {integrity: sha512-m6plojocU/rmrqWd26yvm8D+oHZPZ6PtSSFmZIgpNDEPVmc8s4fBD6LXOAB5MiPI5f8KLUr2HVhOMZ97o5pDTw==}
+  /@storybook/mdx2-csf/1.0.0-next.8:
+    resolution: {integrity: sha512-t2O5s/HHTH5evZVHgVtCWTZgMZ/CaqDu3xVGgjVbKeTvpPAbi0Waab5SSX8T9PG5jNDei/x+jpAVCcNMOHoWzg==}
     dev: true
 
   /@storybook/node-logger/7.0.0-rc.7:
@@ -3857,7 +3863,7 @@ packages:
       '@storybook/channels': 7.0.0-rc.7
       '@storybook/client-logger': 7.0.0-rc.7
       '@storybook/core-events': 7.0.0-rc.7
-      '@storybook/csf': 0.0.2-next.10
+      '@storybook/csf': 0.0.2-next.11
       '@storybook/global': 5.0.0
       '@storybook/types': 7.0.0-rc.7
       '@types/qs': 6.9.7
@@ -3871,16 +3877,16 @@ packages:
       util-deprecate: 1.0.2
     dev: true
 
-  /@storybook/preview-api/7.0.0-rc.9:
-    resolution: {integrity: sha512-KcbqKm4Ge0G8iZNzCnIzGKY7ZD4L6140BQexid0t6dDvBRGavkUXvg3IH+nzXFTHW4H9lW3yFY3zbPANjUexXw==}
+  /@storybook/preview-api/7.0.1:
+    resolution: {integrity: sha512-7MIDCND5plj1RSuCUnRBlJGkH4lBr3j8fIqqmzkoBaw7sMggtWlgGg6lF9j/OOzirpQeDKf4pjKhF0DdL6UAWw==}
     dependencies:
-      '@storybook/channel-postmessage': 7.0.0-rc.9
-      '@storybook/channels': 7.0.0-rc.9
-      '@storybook/client-logger': 7.0.0-rc.9
-      '@storybook/core-events': 7.0.0-rc.9
-      '@storybook/csf': 0.0.2-next.10
+      '@storybook/channel-postmessage': 7.0.1
+      '@storybook/channels': 7.0.1
+      '@storybook/client-logger': 7.0.1
+      '@storybook/core-events': 7.0.1
+      '@storybook/csf': 0.1.0
       '@storybook/global': 5.0.0
-      '@storybook/types': 7.0.0-rc.9
+      '@storybook/types': 7.0.1
       '@types/qs': 6.9.7
       dequal: 2.0.3
       lodash: 4.17.21
@@ -3948,8 +3954,8 @@ packages:
   /@storybook/testing-library/0.0.14-next.1:
     resolution: {integrity: sha512-1CAl40IKIhcPaCC4pYCG0b9IiYNymktfV/jTrX7ctquRY3akaN7f4A1SippVHosksft0M+rQTFE0ccfWW581fw==}
     dependencies:
-      '@storybook/client-logger': 7.0.0-rc.9
-      '@storybook/instrumenter': 7.0.0-rc.9
+      '@storybook/client-logger': 7.0.1
+      '@storybook/instrumenter': 7.0.1
       '@testing-library/dom': 8.20.0
       '@testing-library/user-event': 13.5.0_yxlyej73nftwmh2fiao7paxmlm
       ts-dedent: 2.2.0
@@ -3983,10 +3989,10 @@ packages:
       file-system-cache: 2.0.2
     dev: true
 
-  /@storybook/types/7.0.0-rc.9:
-    resolution: {integrity: sha512-fnlEM+p1h8KAESKa0g+JK6FC5pwS6rci+vG1TexzMWPyk87bJeqZb7aFhhhd5t7UK5CQnZjka9t8RXD7atXk7A==}
+  /@storybook/types/7.0.1:
+    resolution: {integrity: sha512-Tpmxv0cZzujB6fktjf5hHZk9nBMQ5dA+dez3avGfow3BkSuqSZgNZ3NF5Bb6sDR/ccO2hWh+zttZqfS4SngVvQ==}
     dependencies:
-      '@storybook/channels': 7.0.0-rc.9
+      '@storybook/channels': 7.0.1
       '@types/babel__core': 7.20.0
       '@types/express': 4.17.17
       file-system-cache: 2.0.2
@@ -12517,8 +12523,8 @@ packages:
       vitepress: 1.0.0-alpha.63_dbqooz3m3qpdoofqkclhuyaywu
     dev: false
 
-  /vitepress-shopware-docs/0.3.0-beta.36_nmj5hrc277vwxcagfboopqgrjq:
-    resolution: {integrity: sha512-CP4eHnznHnwP73tf0/Gz3Lht6dsNV0TECXvQj40wp4OKdBsaQD4BLs3UDNLl477wNflpaQe0XCp/Q6HBaUR4ww==}
+  /vitepress-shopware-docs/0.3.0-beta.37_nmj5hrc277vwxcagfboopqgrjq:
+    resolution: {integrity: sha512-yRmT5/tfOu/xg0/7amz5xTxUBlOOYmRlUUsCn1QCGJVcBPK5XrT/KwJ1/+LZIjxQa/G+CxikkRaXyNfilz7pIA==}
     dependencies:
       '@docsearch/css': 3.3.3
       '@docsearch/js': 3.3.3_biqbaboplfbrettd7655fr4n2y


### PR DESCRIPTION
 - Link stoplight docs (externally) from resources
 - Unembed `meteor-icon-kit` + link externally
 - Unembed `admin-component-sdk` + link externally
 - Unembed `frontends` + link externally
 - Link Stoplight APIs (externally)
 - Skip unembedded tests