### PR TITLE
[NEXT] DX-336 - Re-embed meteor-icon-kit

### DIFF
--- a/.github/scripts/embed.sh
+++ b/.github/scripts/embed.sh
@@ -77,13 +77,13 @@ fi
 # --dst resources/admin-extension-sdk \
 # --org ${ORG_ADMIN_EXTENSION_SDK:-shopware}
 
-#./docs-cli clone \
-# --ci \
-# --repository shopware/meteor-icon-kit \
-# --branch ${BRANCH_METEOR_ICON_KIT:-main} \
-# --src docs \
-# --dst resources/meteor-icon-kit \
-# --org ${ORG_METEOR_ICON_KIT:-shopware}
+./docs-cli clone \
+ --ci \
+ --repository shopware/meteor-icon-kit \
+ --branch ${BRANCH_METEOR_ICON_KIT:-main} \
+ --src docs \
+ --dst resources/meteor-icon-kit \
+ --org ${ORG_METEOR_ICON_KIT:-shopware}
 
 #./docs-cli clone \
 # --ci \

--- a/.vitepress/navigation.ts
+++ b/.vitepress/navigation.ts
@@ -54,8 +54,7 @@ const navigation = buildSidebarNav('./src/', [
                     },
                     {
                         text: "Meteor Icon Kit",
-                        //link: "/resources/meteor-icon-kit/",
-                        link: 'https://shopware.github.io/meteor-icon-kit/',
+                        link: "/resources/meteor-icon-kit/",
                         repo: 'shopware/meteor-icon-kit',
                     },
                     {
@@ -88,6 +87,7 @@ const navigation = buildSidebarNav('./src/', [
     //'/resources/admin-extension-sdk/',
     //'/resources/meteor-component-library/',
     '/', // always have root sidebar
+    '/resources/meteor-icon-kit/',
 ]);
 
 export default navigation;

--- a/__tests__/cli/command/embed.test.ts
+++ b/__tests__/cli/command/embed.test.ts
@@ -60,8 +60,8 @@ describe('cli embed', async () => {
         //expect(result.stdout).toContain('Embedding shopware/admin-extension-sdk');
         //expect(result.stdout).toContain('Processed shopware/admin-extension-sdk');
 
-        //expect(result.stdout).toContain('Embedding shopware/meteor-icon-kit');
-        //expect(result.stdout).toContain('Processed shopware/meteor-icon-kit');
+        expect(result.stdout).toContain('Embedding shopware/meteor-icon-kit');
+        expect(result.stdout).toContain('Processed shopware/meteor-icon-kit');
 
         //expect(result.stdout).toContain('Embedding shopware/meteor-component-library');
         //expect(result.stdout).toContain('Processed shopware/meteor-component-library');

--- a/__tests__/e2e/meteor-icon-kit/index.test.ts
+++ b/__tests__/e2e/meteor-icon-kit/index.test.ts
@@ -1,7 +1,7 @@
 import {Embedded} from "../page-objects/embedded";
 import {eachLocator} from "../utils/locator";
 
-describe.skip('render correct content', async () => {
+describe('render correct content', async () => {
     let embeddedPage: Embedded;
     const fourOhFour = [];
 


### PR DESCRIPTION
This PR re-embeds meteor-icon-kit by:
 - activating the embedding of the repository
 - linking to the internal URL
 - creating a sidebar (empty)
 - expecting embedding in the tests