### PR TITLE
[NEXT] DX-336 - Re-embed meteor-component-library

### DIFF
--- a/.github/scripts/embed.sh
+++ b/.github/scripts/embed.sh
@@ -85,10 +85,10 @@ fi
 # --dst resources/meteor-icon-kit \
 # --org ${ORG_METEOR_ICON_KIT:-shopware}
 
-#./docs-cli clone \
-# --ci \
-# --repository shopware/meteor-component-library \
-# --branch ${BRANCH_METEOR_COMPONENT_LIBRARY:-main} \
-# --src docs \
-# --dst resources/meteor-component-library \
-# --org ${ORG_METEOR_COMPONENT_LIBRARY:-shopware}
+./docs-cli clone \
+ --ci \
+ --repository shopware/meteor-component-library \
+ --branch ${BRANCH_METEOR_COMPONENT_LIBRARY:-main} \
+ --src docs \
+ --dst resources/meteor-component-library \
+ --org ${ORG_METEOR_COMPONENT_LIBRARY:-shopware}

--- a/.vitepress/navigation.ts
+++ b/.vitepress/navigation.ts
@@ -86,8 +86,8 @@ const navigation = buildSidebarNav('./src/', [
     '/docs/v6.4/',
     '/docs/v6.3/',
     //'/resources/admin-extension-sdk/',
-    //'/resources/meteor-component-library/',
     '/', // always have root sidebar
+    '/resources/meteor-component-library/',
 ]);
 
 export default navigation;

--- a/__tests__/cli/command/embed.test.ts
+++ b/__tests__/cli/command/embed.test.ts
@@ -63,8 +63,8 @@ describe('cli embed', async () => {
         //expect(result.stdout).toContain('Embedding shopware/meteor-icon-kit');
         //expect(result.stdout).toContain('Processed shopware/meteor-icon-kit');
 
-        //expect(result.stdout).toContain('Embedding shopware/meteor-component-library');
-        //expect(result.stdout).toContain('Processed shopware/meteor-component-library');
+        expect(result.stdout).toContain('Embedding shopware/meteor-component-library');
+        expect(result.stdout).toContain('Processed shopware/meteor-component-library');
 
         //expect(result.stdout).toContain('Running additional steps');
 

--- a/__tests__/e2e/meteor-component-library/index.test.ts
+++ b/__tests__/e2e/meteor-component-library/index.test.ts
@@ -1,6 +1,6 @@
 import {Embedded} from "../page-objects/embedded";
 
-describe.skip('render correct content', async () => {
+describe('render correct content', async () => {
     let embeddedPage: Embedded;
 
     beforeAll(async () => {

--- a/cli/src/data.ts
+++ b/cli/src/data.ts
@@ -78,6 +78,5 @@ export const repositories = [
         dst: 'resources/meteor-component-library',
         branch: env.BRANCH_METEOR_COMPONENT_LIBRARY || 'DX-231' || 'main',
         org: env.ORG_METEOR_COMPONENT_LIBRARY || 'bojanrajh',
-        skip: true,
     }
 ];


### PR DESCRIPTION
This PR re-embeds meteor-component-library by:
 - activating the embedding of the repository
 - linking to the internal URL
 - creating a sidebar (empty)
 - expecting embedding in the tests