### PR TITLE
[NEXT] DX-336 - Re-embed admin-extension-sdk

### DIFF
--- a/.github/scripts/embed.sh
+++ b/.github/scripts/embed.sh
@@ -69,13 +69,13 @@ fi
 # --dst frontends-gl \
 # --git gitlab.shopware.com
 
-#./docs-cli clone \
-# --ci \
-# --repository shopware/admin-extension-sdk \
-# --branch ${BRANCH_ADMIN_EXTENSION_SDK:-main} \
-# --src docs/docs/guide \
-# --dst resources/admin-extension-sdk \
-# --org ${ORG_ADMIN_EXTENSION_SDK:-shopware}
+./docs-cli clone \
+ --ci \
+ --repository shopware/admin-extension-sdk \
+ --branch ${BRANCH_ADMIN_EXTENSION_SDK:-main} \
+ --src docs/docs/guide \
+ --dst resources/admin-extension-sdk \
+ --org ${ORG_ADMIN_EXTENSION_SDK:-shopware}
 
 #./docs-cli clone \
 # --ci \

--- a/.vitepress/navigation.ts
+++ b/.vitepress/navigation.ts
@@ -48,8 +48,7 @@ const navigation = buildSidebarNav('./src/', [
                 items: [
                     {
                         text: "Admin Extension SDK",
-                        // link: "/resources/admin-extension-sdk/",
-                        link: 'https://shopware.github.io/admin-extension-sdk/',
+                        link: "/resources/admin-extension-sdk/",
                         repo: 'shopware/admin-extension-sdk',
                     },
                     {
@@ -85,7 +84,7 @@ const navigation = buildSidebarNav('./src/', [
     '/docs/',
     '/docs/v6.4/',
     '/docs/v6.3/',
-    //'/resources/admin-extension-sdk/',
+    '/resources/admin-extension-sdk/',
     //'/resources/meteor-component-library/',
     '/', // always have root sidebar
 ]);

--- a/__tests__/cli/command/embed.test.ts
+++ b/__tests__/cli/command/embed.test.ts
@@ -57,8 +57,8 @@ describe('cli embed', async () => {
         //expect(result.stdout).toContain('Embedding shopware/frontends');
         //expect(result.stdout).toContain('Processed shopware/frontends');
 
-        //expect(result.stdout).toContain('Embedding shopware/admin-extension-sdk');
-        //expect(result.stdout).toContain('Processed shopware/admin-extension-sdk');
+        expect(result.stdout).toContain('Embedding shopware/admin-extension-sdk');
+        expect(result.stdout).toContain('Processed shopware/admin-extension-sdk');
 
         //expect(result.stdout).toContain('Embedding shopware/meteor-icon-kit');
         //expect(result.stdout).toContain('Processed shopware/meteor-icon-kit');

--- a/__tests__/e2e/admin-extension-sdk/index.test.ts
+++ b/__tests__/e2e/admin-extension-sdk/index.test.ts
@@ -1,6 +1,6 @@
 import {Embedded} from "../page-objects/embedded";
 
-describe.skip('render correct content', async () => {
+describe('render correct content', async () => {
     let embeddedPage: Embedded;
 
     beforeAll(async () => {

--- a/cli/src/data.ts
+++ b/cli/src/data.ts
@@ -54,7 +54,6 @@ export const repositories = [
         dst: 'resources/admin-extension-sdk',
         branch: env.BRANCH_ADMIN_EXTENSION_SDK || 'DX-223' || 'main',
         org: env.ORG_ADMIN_EXTENSION_SDK || 'shopware',
-        skip: true,
     },
     {
         name: 'shopware/meteor-icon-kit',


### PR DESCRIPTION
This PR re-embeds admin-extension-sdk by:
 - activating the embedding of the repository
 - linking to the internal URL
 - creating a sidebar (empty)
 - expecting embedding in the tests