### PR TITLE
[NEXT] DX-336 - Re-embed frontends

### DIFF
--- a/.github/scripts/embed.sh
+++ b/.github/scripts/embed.sh
@@ -51,13 +51,13 @@ fi
  --dst docs/v6.3 \
  --org ${ORG_DOCS_63:-shopware}
 
-#./docs-cli clone \
-# --ci \
-# --repository shopware/frontends \
-# --branch ${BRANCH_FRONTENDS:-main} \
-# --src apps/docs/src \
-# --dst frontends \
-# --org ${ORG_FRONTENDS:-shopware}
+./docs-cli clone \
+ --ci \
+ --repository shopware/frontends \
+ --branch ${BRANCH_FRONTENDS:-main} \
+ --src apps/docs/src \
+ --dst frontends \
+ --org ${ORG_FRONTENDS:-shopware}
 
 #./docs-cli clone \
 # --ci \

--- a/.vitepress/navigation.ts
+++ b/.vitepress/navigation.ts
@@ -12,8 +12,7 @@ const navigation = buildSidebarNav('./src/', [
         text: 'Themes',
     },
     {
-        //link: '/frontends/',
-        link: 'https://shopware-frontends-docs.vercel.app/',
+        link: '/frontends/',
         text: 'Frontends',
         repo: 'shopware/frontends',
     },

--- a/__tests__/cli/command/embed.test.ts
+++ b/__tests__/cli/command/embed.test.ts
@@ -54,8 +54,8 @@ describe('cli embed', async () => {
         expect(result.stdout).toContain('Embedding shopware/docs');
         expect(result.stdout).toContain('Processed shopware/docs');
 
-        //expect(result.stdout).toContain('Embedding shopware/frontends');
-        //expect(result.stdout).toContain('Processed shopware/frontends');
+        expect(result.stdout).toContain('Embedding shopware/frontends');
+        expect(result.stdout).toContain('Processed shopware/frontends');
 
         //expect(result.stdout).toContain('Embedding shopware/admin-extension-sdk');
         //expect(result.stdout).toContain('Processed shopware/admin-extension-sdk');

--- a/__tests__/e2e/frontends/index.test.ts
+++ b/__tests__/e2e/frontends/index.test.ts
@@ -1,6 +1,6 @@
 import {Embedded} from "../page-objects/embedded";
 
-describe.skip('render correct content', async () => {
+describe('render correct content', async () => {
     let embeddedPage: Embedded;
 
     beforeAll(async () => {


### PR DESCRIPTION
This PR re-embeds frontends by:
 - activating the embedding of the repository
 - linking to the internal URL
 - creating a sidebar (empty)
 - expecting embedding in the tests